### PR TITLE
Update personal information charter

### DIFF
--- a/snapshots/personal-information-charter.html
+++ b/snapshots/personal-information-charter.html
@@ -112,132 +112,126 @@
       <!-- Inserted content starts -->
 
       <div id="whitehall-wrapper">
-
-  <main id="content" role="main" class="whitehall-content"><div id="page" class="corporate-information-pages-show organisation-page">
-
-<div class="organisation natural-england department-for-environment-food-rural-affairs-brand-colour executive-non-departmental-public-body" id="organisation_202">
-  <article><div class="block-1">
-      <div class="inner-block">
-
-<header class="page-header"><div class="logo">
-    <h1><a href="/government/organisations/natural-england"><img alt="Natural England" class="organisation-logo-custom" src="https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/organisation/logo/202/NE-logo.png"/></a></h1>
-
-  </div>
-
-
-</header><nav class="js-stick-at-top-when-scrolling"><h1>Contents</h1>
-    <ol class="dash-list">
-<li><a href="#your-privacy">Your privacy</a></li>
-        <li><a href="#contact">Contact</a></li>
-    </ol></nav>
-</div>
-    </div>
-    <div class="block-2">
-      <div class="inner-block">
-
-        <p class="homepage-link">
-          <a href="/government/organisations/natural-england">Natural England homepage</a>
-</p>        <h1 class="main">Personal information charter</h1>
-        <p class="description">
-          This charter sets out what you can expect from us when we ask for, or hold, your personal information.
-        </p>
-        <div class="body">
-          <div class="govspeak">
-<p>It also covers what we ask from you to help us keep your information up to date.</p>
-
-<h2 id="your-privacy">Your privacy</h2>
-
-<p>We need to handle personal information about you so that we can provide services for you. This is how we look after that information. </p>
-
-<p>When we ask you for personal information, we promise to: </p>
-
-<ul>
-<li>make sure you know why we need it</li>
-  <li>only ask for what we need, and not to collect too much or irrelevant information</li>
-  <li>protect it and make sure nobody has access to it who shouldn&#x2019;t</li>
-  <li>only share it with other organisations when the law allows</li>
-  <li>make sure we don&#x2019;t keep it longer than necessary</li>
-  <li>not make your personal information available for commercial use without your
-permission</li>
-</ul>
-<p>In return, we ask you to: </p>
-
-<ul>
-<li>give us accurate information</li>
-  <li>tell us as soon as possible if there are any changes, such as a new address</li>
-</ul>
-<p>This will help us to keep your information reliable and up to date. </p>
-
-<p>You can get more details on: </p>
-
-<ul>
-<li>how to find out what information we hold about you and how to ask us to correct any
-mistakes</li>
-  <li>agreements we have with other organisations for sharing information</li>
-  <li>circumstances where we can pass on your personal information without telling you, for
-example to prevent and detect crime or to produce anonymised statistics</li>
-  <li>our instructions to staff on how to collect, use and delete your personal information</li>
-  <li>how we check the information we hold is accurate and up to date</li>
-  <li>how to make a complaint</li>
-</ul>
-<h2 id="contact">Contact</h2>
-
-<div class="contact postal-address" id="contact_2185">
-  <div class="content">
-    <h3>Enquiries team</h3>
-
-    <div class="vcard contact-inner">
-        <p class="adr">
-<span class="fn">Natural England</span><br/><span class="street-address">Block B, Government Buildings, Whittington Road</span><br/><span class="locality">Worcester</span><br/><span class="postal-code">WR5 2LQ</span>
-</p>
-
-
-        <div class="email-url-number">
-            <p class="email">
-              <span class="type">Email</span>
-              <a class="email" href="mailto:enquiries@naturalengland.org.uk">enquiries@naturalengland.org.uk</a>
-            </p>
-            <p class="tel">
-              <span class="type">Telephone</span>
-              0300 060 3900
-            </p>
-        </div>
-
-        <p class="comments">Opening times: 8:30am to 5:00pm, Monday to Friday</p>
-
-    </div>
-  </div>
-</div>
-
-<p>For independent advice about data protection, privacy and data-sharing issues, you can contact the <a rel="external" href="http://www.ico.gov.uk/">Information Commissioner&#x2019;s Office</a>.</p>
-</div>
-        </div>
+  <main class="whitehall-content" id="content" role="main">
+    <div class="corporate-information-pages-show organisation-page" id="page">
+      <div class="organisation natural-england department-for-environment-food-rural-affairs-brand-colour executive-non-departmental-public-body" id="organisation_202">
+        <article>
+          <div class="block-1">
+            <div class="inner-block">
+              <header class="page-header">
+                <div class="logo">
+                  <h1><a href="/government/organisations/natural-england"><img alt="Natural England" class="organisation-logo-custom" src=
+                  "/government/uploads/system/uploads/organisation/logo/202/NE-logo.png"></a></h1>
+                </div>
+              </header>
+              <nav>
+                <h1>Contents</h1>
+                <ol class="dash-list">
+                  <li>
+                    <a href="#how-we-use-your-information">How we use your information</a>
+                  </li>
+                  <li>
+                    <a href="#data-protection-find-out-what-information-we-hold">Data protection: find out what information we hold</a>
+                  </li>
+                  <li>
+                    <a href="#when-we-can-pass-on-your-information">When we can pass on your information</a>
+                  </li>
+                  <li>
+                    <a href="#contact-us">Contact us</a>
+                  </li>
+                </ol>
+              </nav>
+            </div>
+          </div>
+          <div class="block-2">
+            <div class="inner-block">
+              <p class="homepage-link"><a href="/government/organisations/natural-england">Natural England homepage</a></p>
+              <h1 class="main">Personal information charter</h1>
+              <p class="description">This charter explains how we handle and share your personal information, and what we need from you to keep it up to date.</p>
+              <div class="body">
+                <div class="govspeak">
+                  <h2 id="how-we-use-your-information">How we use your information</h2>
+                  <p>We need to handle your personal information so that we can provide services for you.</p>
+                  <p>When we ask you for personal information, we promise:</p>
+                  <ul>
+                    <li>to tell you why we need it</li>
+                    <li>to collect only what we need and delete what we don’t</li>
+                    <li>to protect it and make sure nobody has access to it who shouldn’t</li>
+                    <li>not to make it available for commercial use without your permission</li>
+                  </ul>
+                  <p>In return, we ask you to:</p>
+                  <ul>
+                    <li>give us accurate information</li>
+                    <li>tell us if anything changes, eg your address</li>
+                  </ul>
+                  <p>This helps us make sure the information we hold is accurate and up to date.</p>
+                  <h2 id="data-protection-find-out-what-information-we-hold">Data protection: find out what information we hold</h2>
+                  <p>You can make a ‘subject access request’ under the Data Protection Act 1998, to get a copy of the information we hold about you or someone you’re acting for.</p>
+                  <p>You must get written and signed consent from the person you’re acting for, unless you’re an official appointee, eg you hold power of attorney.</p>
+                  <p>There may be a charge of up to £10.</p>
+                  <p>We’ll send you the information within 40 days of your request.</p>
+                  <h2 id="when-we-can-pass-on-your-information">When we can pass on your information</h2>
+                  <p>We might want to share your information with organisations to improve a service. We’ll ask your permission - you might be able to say no.</p>
+                  <p>Sometimes we can pass on your information without telling you, eg to:</p>
+                  <ul>
+                    <li>prevent a crime</li>
+                    <li>produce anonymised statistics</li>
+                  </ul>
+                  <h2 id="contact-us">Contact us</h2>
+                  <p>Contact us if you want to know more about how we hold your information, or to:</p>
+                  <ul>
+                    <li>tell us there’s a mistake</li>
+                    <li>make a complaint</li>
+                  </ul>
+                  <div class="contact postal-address" id="contact_2185">
+                    <div class="content">
+                      <h3>Enquiries team</h3>
+                      <div class="vcard contact-inner">
+                        <p class="adr"><span class="fn">Natural England</span><br>
+                        <span class="street-address">Block B, Government Buildings, Whittington Road</span><br>
+                        <span class="locality">Worcester</span><br>
+                        <span class="postal-code">WR5 2LQ</span></p>
+                        <div class="email-url-number">
+                          <p class="email"><span class="type">Email</span> <a class="email" href="mailto:enquiries@naturalengland.org.uk">enquiries@naturalengland.org.uk</a></p>
+                          <p class="tel"><span class="type">Telephone</span> 0300 060 3900</p>
+                        </div>
+                        <p class="comments">Opening times: 8:30am to 5:00pm, Monday to Friday</p>
+                      </div>
+                    </div>
+                  </div>
+                  <p>For independent advice about data protection, privacy and data sharing issues, you can contact the <a href="http://www.ico.gov.uk/" rel="external">Information Commissioner’s
+                  Office</a>.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
       </div>
     </div>
-  </article>
-</div>
-
-    </div>
-  </main><div class="report-a-problem-container">
-  <div class="report-a-problem-inner">
-    <div class="report-a-problem-content">
-      <h2 class="js-original-variant">Help us improve GOV.UK</h2>
-      <form accept-charset="UTF-8" action="/contact/govuk/problem_reports" method="post">
-        <div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;"/></div>
-        <input id="url" name="url" type="hidden" value="https://www.gov.uk/government/organisations/natural-england/about/personal-information-charter"/><input id="source" name="source" type="hidden" value="inside_government"/><input id="page_owner" name="page_owner" type="hidden" value="natural_england"/><div class="js-original-variant">
-          <p>Don&#x2019;t include personal or financial information, eg your National Insurance number or credit card details.</p>
-
-          <label for="what_doing">What you were doing</label>
-          <input id="what_doing" name="what_doing" type="text"/><label for="what_wrong">What went wrong</label>
-          <input id="what_wrong" name="what_wrong" type="text"/>
-</div>
-        <div class="button-wrapper">
-          <button name="commit" type="submit" class="button">Send</button>
-        </div>
-      </form>
+  </main>
+  <div class="report-a-problem-toggle-wrapper js-footer">
+    <p class="report-a-problem-toggle"><a class="js-report-a-problem-toggle" href="">Is there anything wrong with this page?</a></p>
+  </div>
+  <div class="report-a-problem-container">
+    <div class="report-a-problem-inner">
+      <div class="report-a-problem-content">
+        <h2>Help us improve GOV.UK</h2>
+        <form accept-charset="UTF-8" action="/contact/govuk/problem_reports" method="post">
+          <div style="margin:0;padding:0;display:inline">
+            <input name="utf8" type="hidden" value="✓">
+          </div><input id="url" name="url" type="hidden" value=
+          "https://whitehall-admin.preview.alphagov.co.uk/government/organisations/natural-england/about/personal-information-charter?cachebust=1445948760&amp;preview=556615"> <input id="source"
+          name="source" type="hidden" value="inside_government"> <input id="page_owner" name="page_owner" type="hidden" value="natural_england">
+          <p>Don’t include personal or financial information, eg your National Insurance number or credit card details.</p><label for="what_doing">What you were doing</label> <input id="what_doing"
+          name="what_doing" type="text"> <label for="what_wrong">What went wrong</label> <input id="what_wrong" name="what_wrong" type="text">
+          <div class="button-wrapper">
+            <button class="button" name="commit" type="submit">Send</button>
+          </div><input name="javascript_enabled" type="hidden" value="true"><input name="referrer" type="hidden" value=
+          "https://whitehall-admin.preview.alphagov.co.uk/government/admin/organisations/natural-england/corporate_information_pages/556615">
+        </form>
+      </div>
     </div>
   </div>
-</div>
 </div>
 
       <!-- Inserted content ends -->


### PR DESCRIPTION
Created better example of a personal information charter. Changed from PDF to HTML in Github.

Part of One Guidance.
